### PR TITLE
Fix http server issues with "Peer-Address" messages on Ubuntu 16.04

### DIFF
--- a/doc/Changelog.md
+++ b/doc/Changelog.md
@@ -4,6 +4,8 @@
 
 # Release 0.6 (30-06-2016)
 
+* [179](https://github.com/HBPVIS/ZeroEQ/pull/179):
+  Fix http server blocking issues with libzmq 4.1.4
 * [170](https://github.com/HBPVIS/ZeroEQ/pull/170):
   Remove FlatBuffers dependency and support
 * [169](https://github.com/HBPVIS/ZeroEQ/pull/169):


### PR DESCRIPTION
These unexpected messages caused Tide's RestServer to block the main
thread after each http request in zmq_recv() at line 144 of
zeroeq/http/server.cpp.

The exact combination of operations in this patch is necessary to ensure
that none of the following unit tests block indefinitely:

- zeroeq/http/server - issue157
- tide/cpp/core/RestServerTests - testServerReturnsSimpleContent

and that normal receive operations (as tested with Tide's REST interface)
still work as expected (no messages skipped due to zmq_errno() == EAGAIN)