### PR TITLE
Fix build with clang 3.5 (Apple LLVM 6.0)

### DIFF
--- a/tests/http/server.cpp
+++ b/tests/http/server.cpp
@@ -223,7 +223,8 @@ private:
     void _checkImpl(const zeroeq::http::Method method,
                     const std::string& request, const std::string& data,
                     const Response& expected, const int line,
-                    std::map<std::string, std::string> requestHeaders = {})
+                    const std::map<std::string, std::string> requestHeaders =
+                        std::map<std::string, std::string>{})
     {
         HTTPClient::request request_(_baseURL + request);
         for (const auto& h : requestHeaders)
@@ -652,7 +653,7 @@ BOOST_AUTO_TEST_CASE(handle_root)
     zeroeq::http::Server server;
 
     server.handle(zeroeq::http::Method::GET, "",
-                  [this](const zeroeq::http::Request&) {
+                  [](const zeroeq::http::Request&) {
                       return zeroeq::http::make_ready_response(
                           zeroeq::http::Code::OK, "homepage", "text/html");
                   });
@@ -714,7 +715,7 @@ BOOST_AUTO_TEST_CASE(handle_root_and_root_path)
     zeroeq::http::Server server;
     server.handle(zeroeq::http::Method::GET, "/", echoFunc);
     server.handle(zeroeq::http::Method::GET, "",
-                  [this](const zeroeq::http::Request&) {
+                  [](const zeroeq::http::Request&) {
                       return zeroeq::http::make_ready_response(
                           zeroeq::http::Code::OK, "homepage", "text/html");
                   });


### PR DESCRIPTION
However the http-server tests fail on my mac, I haven't been able to figure out why:

libc++abi.dylib: terminating with uncaught exception of type std::__1::bad_function_call: std::exception
unknown location:0: fatal error: in "get_serializable": signal: SIGABRT (application abort requested)
../ZeroEQ/tests/http/server.cpp:458: last checkpoint
unknown location:0: fatal error: in "get_event": memory access violation at address: 0x09f14cb0: no mapping at fault address
../ZeroEQ/tests/http/server.cpp:467: last checkpoint: "get_event" entry.
