### PR TITLE
Failsafe when announcement is not supported by Servus.

### DIFF
--- a/doc/Changelog.md
+++ b/doc/Changelog.md
@@ -2,6 +2,8 @@
 
 # git master
 
+* [226](https://github.com/HBPVIS/ZeroEQ/pull/226):
+  Better failsafe when announcement is not supported by Servus
 * [225](https://github.com/HBPVIS/ZeroEQ/pull/225):
   Fix #224: Handle exceptions in server handlers
 * [219](https://github.com/HBPVIS/ZeroEQ/pull/219):

--- a/zeroeq/detail/sender.cpp
+++ b/zeroeq/detail/sender.cpp
@@ -99,6 +99,13 @@ void Sender::announce()
         _service.set(KEY_SESSION, _session);
 
     const auto& result = _service.announce(uri.getPort(), getAddress());
+    if (result == servus::Servus::Result::NOT_SUPPORTED)
+    {
+        ZEROEQWARN << "ZeroEQ::Sender: Cannot announce on Zeroconf; no "
+                      "implementation provided by Servus"
+                   << std::endl;
+        return;
+    }
     if (!result)
         ZEROEQTHROW(std::runtime_error("Zeroconf announce failed: " +
                                        result.getString()));


### PR DESCRIPTION
This covers the case of an avahi daemon not running for example.
In this case checking Servus::isAvailable() is not enough.